### PR TITLE
feat: open NPI search in modal

### DIFF
--- a/client/src/pages/hospitals/EditHospital.jsx
+++ b/client/src/pages/hospitals/EditHospital.jsx
@@ -1,5 +1,5 @@
 import { useNavigate } from 'react-router';
-import { Container, Grid } from '@mantine/core';
+import { Container } from '@mantine/core';
 
 import HospitalForm from './hospital-details/Components/HospitalForm';
 
@@ -17,11 +17,7 @@ export default function EditHospital () {
   return (
     <Container component='main'>
       <h1>Edit Hospital</h1>
-      <Grid>
-        <Grid.Col span={{ base: 12, md: 6 }}>
-          <HospitalForm onSuccess={onSuccess} onError={onError} />
-        </Grid.Col>
-      </Grid>
+      <HospitalForm onSuccess={onSuccess} onError={onError} />
     </Container>
   );
 }

--- a/client/src/pages/hospitals/EditHospital.jsx
+++ b/client/src/pages/hospitals/EditHospital.jsx
@@ -1,5 +1,5 @@
 import { useNavigate } from 'react-router';
-import { Container } from '@mantine/core';
+import { Container, Grid } from '@mantine/core';
 
 import HospitalForm from './hospital-details/Components/HospitalForm';
 
@@ -17,7 +17,11 @@ export default function EditHospital () {
   return (
     <Container component='main'>
       <h1>Edit Hospital</h1>
-      <HospitalForm onSuccess={onSuccess} onError={onError} />
+      <Grid>
+        <Grid.Col span={{ base: 12, md: 6 }}>
+          <HospitalForm onSuccess={onSuccess} onError={onError} />
+        </Grid.Col>
+      </Grid>
     </Container>
   );
 }

--- a/client/src/pages/hospitals/NpiSearch.jsx
+++ b/client/src/pages/hospitals/NpiSearch.jsx
@@ -13,6 +13,12 @@ export default function NpiSearch ({ initialName = '', onSelect }) {
     setName(initialName);
   }, [initialName]);
 
+  function formatPhone (phone) {
+    return phone.length === 10
+      ? `(${phone.slice(0, 3)}) ${phone.slice(3, 6)}-${phone.slice(6)}`
+      : phone;
+  }
+
   async function handleSubmit (event) {
     event.preventDefault();
     if (!name || state.length !== 2) return;
@@ -28,7 +34,11 @@ export default function NpiSearch ({ initialName = '', onSelect }) {
         throw new Error('Failed to fetch');
       }
       const data = await response.json();
-      setResults(data);
+      const mapped = data.map(row => ({
+        ...row,
+        phone: row.phone === 'N/A' ? '' : row.phone.replace(/\D/g, '')
+      }));
+      setResults(mapped);
     } catch (err) {
       setError(err.message || 'Error fetching data');
     } finally {
@@ -77,9 +87,13 @@ export default function NpiSearch ({ initialName = '', onSelect }) {
               <Table.Tr key={row.npi}>
                 <Table.Td>{row.name}</Table.Td>
                 <Table.Td>
-                  <Anchor onClick={() => onSelect?.(row.address)}>{row.address}</Anchor>
+                  <Anchor onClick={() => onSelect?.(row)}>{row.address}</Anchor>
                 </Table.Td>
-                <Table.Td>{row.phone}</Table.Td>
+                <Table.Td>
+                  <Anchor onClick={() => onSelect?.(row)}>
+                    {row.phone ? formatPhone(row.phone) : 'N/A'}
+                  </Anchor>
+                </Table.Td>
                 <Table.Td>{row.npi}</Table.Td>
                 <Table.Td>
                   <Anchor

--- a/client/src/pages/hospitals/NpiSearch.jsx
+++ b/client/src/pages/hospitals/NpiSearch.jsx
@@ -1,0 +1,100 @@
+import { useState, useEffect } from 'react';
+import { TextInput, Button, Table, Anchor, Group, Loader, Alert } from '@mantine/core';
+
+export default function NpiSearch ({ initialName = '', onSelect }) {
+  const [name, setName] = useState(initialName);
+  const [state, setState] = useState('');
+  const [results, setResults] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [searched, setSearched] = useState(false);
+
+  useEffect(() => {
+    setName(initialName);
+  }, [initialName]);
+
+  async function handleSubmit (event) {
+    event.preventDefault();
+    if (!name || state.length !== 2) return;
+    setLoading(true);
+    setError('');
+    setResults([]);
+    setSearched(true);
+
+    try {
+      const params = new URLSearchParams({ name, state });
+      const response = await fetch(`/api/v1/npi?${params.toString()}`);
+      if (!response.ok) {
+        throw new Error('Failed to fetch');
+      }
+      const data = await response.json();
+      setResults(data);
+    } catch (err) {
+      setError(err.message || 'Error fetching data');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div>
+      <form onSubmit={handleSubmit}>
+        <Group align='flex-end'>
+          <TextInput
+            label='Organization Name'
+            value={name}
+            onChange={e => setName(e.currentTarget.value)}
+            required
+          />
+          <TextInput
+            label='State'
+            value={state}
+            onChange={e => setState(e.currentTarget.value.toUpperCase())}
+            maxLength={2}
+            required
+          />
+          <Button type='submit' disabled={!name || state.length !== 2}>Search</Button>
+        </Group>
+      </form>
+      {loading && <Loader mt='md' />}
+      {error && <Alert color='red' mt='md'>{error}</Alert>}
+      {!loading && searched && results.length === 0 && !error && (
+        <Alert color='gray' mt='md'>No results found</Alert>
+      )}
+      {results.length > 0 && (
+        <Table striped highlightOnHover mt='md'>
+          <Table.Thead>
+            <Table.Tr>
+              <Table.Th>Name</Table.Th>
+              <Table.Th>Address</Table.Th>
+              <Table.Th>Phone</Table.Th>
+              <Table.Th>NPI</Table.Th>
+              <Table.Th>Map</Table.Th>
+            </Table.Tr>
+          </Table.Thead>
+          <Table.Tbody>
+            {results.map(row => (
+              <Table.Tr key={row.npi}>
+                <Table.Td>{row.name}</Table.Td>
+                <Table.Td>
+                  <Anchor onClick={() => onSelect?.(row.address)}>{row.address}</Anchor>
+                </Table.Td>
+                <Table.Td>{row.phone}</Table.Td>
+                <Table.Td>{row.npi}</Table.Td>
+                <Table.Td>
+                  <Anchor
+                    href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(row.address)}`}
+                    target='_blank'
+                    rel='noopener noreferrer'
+                  >
+                    Map
+                  </Anchor>
+                </Table.Td>
+              </Table.Tr>
+            ))}
+          </Table.Tbody>
+        </Table>
+      )}
+    </div>
+  );
+}

--- a/client/src/pages/hospitals/hospital-details/Components/HospitalForm.jsx
+++ b/client/src/pages/hospitals/hospital-details/Components/HospitalForm.jsx
@@ -69,22 +69,41 @@ export default function HospitalForm ({ onSuccess, onError }) {
   });
 
   return (
-    <form onSubmit={form.onSubmit(mutateAsync)}>
-      <TextInput
-        label='Name'
-        key={form.key('name')}
-        {...form.getInputProps('name')}
-        mb='sm'
-      />
-      <Group align='flex-end' mb='sm'>
+    <>
+      <form onSubmit={form.onSubmit(mutateAsync)}>
         <TextInput
-          label='Address'
-          style={{ flex: 1 }}
-          key={form.key('address')}
-          {...form.getInputProps('address')}
+          label='Name'
+          key={form.key('name')}
+          {...form.getInputProps('name')}
+          mb='sm'
         />
-        <Button onClick={() => setNpiOpen(true)}>Search NPI</Button>
-      </Group>
+        <Group align='flex-end' mb='sm'>
+          <TextInput
+            label='Address'
+            style={{ flex: 1 }}
+            key={form.key('address')}
+            {...form.getInputProps('address')}
+          />
+          <Button type='button' onClick={() => setNpiOpen(true)}>Search NPI</Button>
+        </Group>
+        <TextInput
+          label='Phone'
+          component={IMaskInput}
+          mask='(000) 000-0000'
+          placeholder='(000) 000-0000'
+          key={form.key('phone')}
+          {...form.getInputProps('phone')}
+          mb='sm'
+        />
+        <TextInput
+          label='Email'
+          type='email'
+          key={form.key('email')}
+          {...form.getInputProps('email')}
+          mb='sm'
+        />
+        <Button type='submit'>Submit</Button>
+      </form>
       <Modal
         opened={npiOpen}
         onClose={() => setNpiOpen(false)}
@@ -102,23 +121,6 @@ export default function HospitalForm ({ onSuccess, onError }) {
           }}
         />
       </Modal>
-      <TextInput
-        label='Phone'
-        component={IMaskInput}
-        mask='(000) 000-0000'
-        placeholder='(000) 000-0000'
-        key={form.key('phone')}
-        {...form.getInputProps('phone')}
-        mb='sm'
-      />
-      <TextInput
-        label='Email'
-        type='email'
-        key={form.key('email')}
-        {...form.getInputProps('email')}
-        mb='sm'
-      />
-      <Button type='submit'>Submit</Button>
-    </form>
+    </>
   );
 }

--- a/client/src/pages/hospitals/hospital-details/Components/HospitalForm.jsx
+++ b/client/src/pages/hospitals/hospital-details/Components/HospitalForm.jsx
@@ -118,7 +118,8 @@ export default function HospitalForm ({ onSuccess, onError }) {
           onSelect={selection => {
             form.setFieldValue('address', selection.address);
             if (selection.phone) {
-              form.setFieldValue('phone', selection.phone);
+              const formatted = selection.phone.replace(/(\d{3})(\d{3})(\d{4})/, '($1) $2-$3');
+              form.setFieldValue('phone', formatted);
             }
             setNpiOpen(false);
           }}

--- a/client/src/pages/hospitals/hospital-details/Components/HospitalForm.jsx
+++ b/client/src/pages/hospitals/hospital-details/Components/HospitalForm.jsx
@@ -93,8 +93,11 @@ export default function HospitalForm ({ onSuccess, onError }) {
       >
         <NpiSearch
           initialName={form.getValues().name}
-          onSelect={address => {
-            form.setFieldValue('address', address);
+          onSelect={selection => {
+            form.setFieldValue('address', selection.address);
+            if (selection.phone) {
+              form.setFieldValue('phone', selection.phone);
+            }
             setNpiOpen(false);
           }}
         />

--- a/client/src/pages/hospitals/hospital-details/Components/HospitalForm.jsx
+++ b/client/src/pages/hospitals/hospital-details/Components/HospitalForm.jsx
@@ -1,14 +1,17 @@
 import { useForm } from '@mantine/form';
-import { Button, TextInput } from '@mantine/core';
+import { useState } from 'react';
+import { Button, TextInput, Group, Modal } from '@mantine/core';
 import { useParams } from 'react-router';
 import { IMaskInput } from 'react-imask';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { StatusCodes } from 'http-status-codes';
 
 import LifelineAPI from '#app/LifelineAPI';
+import NpiSearch from '../../NpiSearch';
 
 export default function HospitalForm ({ onSuccess, onError }) {
   const { hospitalId } = useParams();
+  const [npiOpen, setNpiOpen] = useState(false);
 
   const form = useForm({
     mode: 'uncontrolled',
@@ -73,12 +76,29 @@ export default function HospitalForm ({ onSuccess, onError }) {
         {...form.getInputProps('name')}
         mb='sm'
       />
-      <TextInput
-        label='Address'
-        key={form.key('address')}
-        {...form.getInputProps('address')}
-        mb='sm'
-      />
+      <Group align='flex-end' mb='sm'>
+        <TextInput
+          label='Address'
+          style={{ flex: 1 }}
+          key={form.key('address')}
+          {...form.getInputProps('address')}
+        />
+        <Button onClick={() => setNpiOpen(true)}>Search NPI</Button>
+      </Group>
+      <Modal
+        opened={npiOpen}
+        onClose={() => setNpiOpen(false)}
+        title='Search NPI'
+        size='lg'
+      >
+        <NpiSearch
+          initialName={form.getValues().name}
+          onSelect={address => {
+            form.setFieldValue('address', address);
+            setNpiOpen(false);
+          }}
+        />
+      </Modal>
       <TextInput
         label='Phone'
         component={IMaskInput}

--- a/client/src/pages/hospitals/hospital-details/Components/HospitalForm.jsx
+++ b/client/src/pages/hospitals/hospital-details/Components/HospitalForm.jsx
@@ -15,7 +15,7 @@ export default function HospitalForm ({ onSuccess, onError }) {
 
   const form = useForm({
     mode: 'uncontrolled',
-    initalValues: {
+    initialValues: {
       name: '',
       address: '',
       phone: '',
@@ -70,7 +70,10 @@ export default function HospitalForm ({ onSuccess, onError }) {
 
   return (
     <>
-      <form onSubmit={form.onSubmit(mutateAsync)}>
+      <form onSubmit={form.onSubmit(async (values) => {
+        await mutateAsync(values);
+      })}
+      >
         <TextInput
           label='Name'
           key={form.key('name')}

--- a/server/routes/api/v1/npi/index.js
+++ b/server/routes/api/v1/npi/index.js
@@ -1,0 +1,63 @@
+import { StatusCodes } from 'http-status-codes';
+import { z } from 'zod';
+
+const NpiResultSchema = z.object({
+  name: z.string(),
+  address: z.string(),
+  phone: z.string(),
+  npi: z.string(),
+});
+
+export default async function (fastify) {
+  fastify.get(
+    '',
+    {
+      schema: {
+        querystring: z.object({
+          name: z.string().min(1, 'Organization name is required'),
+          state: z.string().length(2, 'State code must be 2 letters'),
+        }),
+        response: {
+          [StatusCodes.OK]: z.array(NpiResultSchema),
+          [StatusCodes.BAD_GATEWAY]: z.object({ message: z.string() }),
+          [StatusCodes.INTERNAL_SERVER_ERROR]: z.object({ message: z.string() }),
+        },
+      },
+    },
+    async (request, reply) => {
+      const { name, state } = request.query;
+      const params = new URLSearchParams({
+        version: '2.1',
+        enumeration_type: 'NPI-2',
+        organization_name: name,
+        state,
+      });
+
+      try {
+        const response = await fetch(`https://npiregistry.cms.hhs.gov/api/?${params.toString()}`);
+        if (!response.ok) {
+          return reply
+            .status(StatusCodes.BAD_GATEWAY)
+            .send({ message: 'Failed to fetch NPI registry' });
+        }
+        const data = await response.json();
+        const results = data.results?.map(result => {
+          const location = result.addresses?.find(addr => addr.address_purpose === 'LOCATION');
+          const address = location
+            ? `${location.address_1}${location.address_2 ? ' ' + location.address_2 : ''}, ${location.city}, ${location.state} ${location.postal_code}`
+            : 'N/A';
+          const phone = location?.telephone_number || 'N/A';
+          const organizationName = result.basic?.organization_name || 'N/A';
+          const npi = String(result.number);
+          return { name: organizationName, address, phone, npi };
+        }) ?? [];
+        return results;
+      } catch (err) {
+        request.log.error(err);
+        return reply
+          .status(StatusCodes.INTERNAL_SERVER_ERROR)
+          .send({ message: 'Error fetching NPI data' });
+      }
+    }
+  );
+}

--- a/server/test/routes/api/v1/npi.test.js
+++ b/server/test/routes/api/v1/npi.test.js
@@ -1,0 +1,93 @@
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert';
+import nock from 'nock';
+import { StatusCodes } from 'http-status-codes';
+
+import { build } from '#test/helper.js';
+
+const registryHost = 'https://npiregistry.cms.hhs.gov';
+
+describe('/api/v1/npi', () => {
+  describe('GET /', () => {
+    it('should return organizations from NPI registry', async (t) => {
+      const scope = nock(registryHost)
+        .get('/api/')
+        .query({
+          version: '2.1',
+          enumeration_type: 'NPI-2',
+          organization_name: 'Kaiser',
+          state: 'CA'
+        })
+        .reply(200, {
+          results: [
+            {
+              number: 1234567890,
+              basic: { organization_name: 'Kaiser Permanente' },
+              addresses: [
+                {
+                  address_purpose: 'LOCATION',
+                  address_1: '123 Main St',
+                  address_2: 'Ste 100',
+                  city: 'San Francisco',
+                  state: 'CA',
+                  postal_code: '94103',
+                  telephone_number: '555-123-4567'
+                }
+              ]
+            }
+          ]
+        });
+
+      const app = await build(t);
+      const res = await app.inject().get('/api/v1/npi?name=Kaiser&state=CA');
+      assert.deepStrictEqual(res.statusCode, StatusCodes.OK);
+      assert.deepStrictEqual(JSON.parse(res.body), [
+        {
+          name: 'Kaiser Permanente',
+          address: '123 Main St Ste 100, San Francisco, CA 94103',
+          phone: '555-123-4567',
+          npi: '1234567890'
+        }
+      ]);
+      scope.done();
+    });
+
+    it('should return BAD_GATEWAY when registry fails', async (t) => {
+      const scope = nock(registryHost)
+        .get('/api/')
+        .query({
+          version: '2.1',
+          enumeration_type: 'NPI-2',
+          organization_name: 'Kaiser',
+          state: 'CA'
+        })
+        .reply(500, {});
+
+      const app = await build(t);
+      const res = await app.inject().get('/api/v1/npi?name=Kaiser&state=CA');
+      assert.deepStrictEqual(res.statusCode, StatusCodes.BAD_GATEWAY);
+      const body = JSON.parse(res.body);
+      assert.deepStrictEqual(body.message, 'Failed to fetch NPI registry');
+      scope.done();
+    });
+
+    it('should handle network errors gracefully', async (t) => {
+      const scope = nock(registryHost)
+        .get('/api/')
+        .query({
+          version: '2.1',
+          enumeration_type: 'NPI-2',
+          organization_name: 'Kaiser',
+          state: 'CA'
+        })
+        .replyWithError('network error');
+
+      const app = await build(t);
+      const res = await app.inject().get('/api/v1/npi?name=Kaiser&state=CA');
+      assert.deepStrictEqual(res.statusCode, StatusCodes.INTERNAL_SERVER_ERROR);
+      const body = JSON.parse(res.body);
+      assert.deepStrictEqual(body.message, 'Error fetching NPI data');
+      scope.done();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- open NPI lookup in a modal triggered from the hospital form
- prefill NPI search with hospital name and allow selecting an address to fill the form

## Testing
- `npm test` (fails: test failed)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d1c48db54833287fc6b68620ec3aa