### PR TITLE
Add region-based hospital map

### DIFF
--- a/client/src/pages/hospitals/Hospitals.jsx
+++ b/client/src/pages/hospitals/Hospitals.jsx
@@ -16,6 +16,7 @@ import { TbSearch as IconSearch } from 'react-icons/tb';
 import HospitalsTable from './HospitalsTable';
 import { useHospitals } from './useHospitals';
 import HospitalModal from './HospitalModal';
+import HospitalsMap from './HospitalsMap';
 
 /**
  *  Hosptials page component
@@ -23,7 +24,9 @@ import HospitalModal from './HospitalModal';
  */
 export default function Hospitals () {
   const [inputValue, setInputValue] = useState('');
+  const [region, setRegion] = useState('');
   const [opened, { open, close }] = useDisclosure(false);
+  const [mapOpened, { open: openMap, close: closeMap }] = useDisclosure(false);
   const { hospitals, headers, isFetching, page, pages, setPage, setSearch } = useHospitals();
 
   const handleSearch = useDebouncedCallback((query) => {
@@ -33,6 +36,7 @@ export default function Hospitals () {
   return (
     <Container>
       <HospitalModal opened={opened} close={close} />
+      <HospitalsMap opened={mapOpened} close={closeMap} region={region} />
       <Group justify='space-between' wrap='nowrap' my='sm'>
         <Title order={3} mr='md'>
           Hospitals
@@ -48,6 +52,14 @@ export default function Hospitals () {
             }}
             value={inputValue}
           />
+          <TextInput
+            placeholder='Region'
+            onChange={(event) => setRegion(event.currentTarget.value)}
+            value={region}
+          />
+          <Button variant='light' onClick={openMap}>
+            View Map
+          </Button>
           <Button variant='filled' onClick={open}>
             Create Hospital
           </Button>

--- a/client/src/pages/hospitals/Hospitals.jsx
+++ b/client/src/pages/hospitals/Hospitals.jsx
@@ -57,7 +57,7 @@ export default function Hospitals () {
             onChange={(event) => setRegion(event.currentTarget.value)}
             value={region}
           />
-          <Button variant='light' onClick={openMap}>
+          <Button variant='light' onClick={openMap} disabled={!region.trim()}>
             View Map
           </Button>
           <Button variant='filled' onClick={open}>

--- a/client/src/pages/hospitals/HospitalsMap.jsx
+++ b/client/src/pages/hospitals/HospitalsMap.jsx
@@ -11,11 +11,17 @@ export default function HospitalsMap ({ opened, close, region }) {
 
   useEffect(() => {
     async function loadMap () {
-      if (!region) return;
+      if (!region) {
+        setMapUrl('');
+        return;
+      }
       setLoading(true);
       try {
         // Get bounding box for the region
-        const res = await fetch(`https://nominatim.openstreetmap.org/search?format=json&limit=1&q=${encodeURIComponent(region)}`);
+        const res = await fetch(
+          `https://nominatim.openstreetmap.org/search?format=json&limit=1&q=${encodeURIComponent(region)}`
+        );
+        if (!res.ok) throw new Error('Location lookup failed');
         const [place] = await res.json();
         if (!place) {
           setMapUrl('');
@@ -23,8 +29,10 @@ export default function HospitalsMap ({ opened, close, region }) {
         }
         const [south, north, west, east] = place.boundingbox;
         // Fetch hospitals in the bounding box
-        const overpassUrl = `https://overpass-api.de/api/interpreter?data=[out:json];node["amenity"="hospital"](${south},${west},${north},${east});out;`;
+        const query = `[out:json];node["amenity"="hospital"](${south},${west},${north},${east});out;`;
+        const overpassUrl = `https://overpass-api.de/api/interpreter?data=${encodeURIComponent(query)}`;
         const overpass = await fetch(overpassUrl);
+        if (!overpass.ok) throw new Error('Overpass query failed');
         const overpassData = await overpass.json();
         const markers = overpassData.elements
           .filter((e) => e.lat && e.lon)
@@ -33,6 +41,7 @@ export default function HospitalsMap ({ opened, close, region }) {
         const url = `https://staticmap.openstreetmap.de/staticmap.php?bbox=${west},${south},${east},${north}&size=865x512&markers=${markers}`;
         setMapUrl(url);
       } catch (err) {
+        console.error(err);
         setMapUrl('');
       } finally {
         setLoading(false);
@@ -51,7 +60,10 @@ export default function HospitalsMap ({ opened, close, region }) {
       {!loading && mapUrl && (
         <img src={mapUrl} alt={`Hospitals in ${region}`} style={{ width: '100%' }} />
       )}
-      {!loading && !mapUrl && (
+      {!loading && !region && (
+        <Text>Enter a region to view the map.</Text>
+      )}
+      {!loading && region && !mapUrl && (
         <Text>No map data available.</Text>
       )}
     </Modal>

--- a/client/src/pages/hospitals/HospitalsMap.jsx
+++ b/client/src/pages/hospitals/HospitalsMap.jsx
@@ -1,0 +1,59 @@
+import { Modal, Loader, Center, Text } from '@mantine/core';
+import { useEffect, useState } from 'react';
+
+/**
+ * Displays a static map of hospitals within the provided region.
+ * The map is generated using OpenStreetMap's public APIs.
+ */
+export default function HospitalsMap ({ opened, close, region }) {
+  const [mapUrl, setMapUrl] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    async function loadMap () {
+      if (!region) return;
+      setLoading(true);
+      try {
+        // Get bounding box for the region
+        const res = await fetch(`https://nominatim.openstreetmap.org/search?format=json&limit=1&q=${encodeURIComponent(region)}`);
+        const [place] = await res.json();
+        if (!place) {
+          setMapUrl('');
+          return;
+        }
+        const [south, north, west, east] = place.boundingbox;
+        // Fetch hospitals in the bounding box
+        const overpassUrl = `https://overpass-api.de/api/interpreter?data=[out:json];node["amenity"="hospital"](${south},${west},${north},${east});out;`;
+        const overpass = await fetch(overpassUrl);
+        const overpassData = await overpass.json();
+        const markers = overpassData.elements
+          .filter((e) => e.lat && e.lon)
+          .map((e) => `${e.lat},${e.lon},red-pushpin`)
+          .join('|');
+        const url = `https://staticmap.openstreetmap.de/staticmap.php?bbox=${west},${south},${east},${north}&size=865x512&markers=${markers}`;
+        setMapUrl(url);
+      } catch (err) {
+        setMapUrl('');
+      } finally {
+        setLoading(false);
+      }
+    }
+    if (opened) loadMap();
+  }, [opened, region]);
+
+  return (
+    <Modal opened={opened} onClose={close} size='xl' title='Hospitals Map'>
+      {loading && (
+        <Center h={400}>
+          <Loader />
+        </Center>
+      )}
+      {!loading && mapUrl && (
+        <img src={mapUrl} alt={`Hospitals in ${region}`} style={{ width: '100%' }} />
+      )}
+      {!loading && !mapUrl && (
+        <Text>No map data available.</Text>
+      )}
+    </Modal>
+  );
+}


### PR DESCRIPTION
## Summary
- show hospitals map by region using OpenStreetMap APIs
- add region input and map modal on hospitals page

## Testing
- `npm test` (fails: @prisma/client did not initialize yet)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e69ef39148332a2f71d76eeb2e6ed