### PR TITLE
Add UI and API support to link physicians to hospitals

### DIFF
--- a/client/src/LifelineAPI.js
+++ b/client/src/LifelineAPI.js
@@ -206,6 +206,16 @@ export default class LifelineAPI {
     return response;
   }
 
+  static async linkPhysiciansToHospital (hospitalId, physicianIds) {
+    return fetch(`${SERVER_BASE_URL}/hospitals/${hospitalId}/physicians`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ physicianIds }),
+    });
+  }
+
   static async deleteHospital (hospitalId) {
     const response = await fetch(
       `${SERVER_BASE_URL}/hospitals/${hospitalId}`,

--- a/client/src/pages/hospitals/hospital-details/Components/PhysiciansComponent/AddPhysicianModal.jsx
+++ b/client/src/pages/hospitals/hospital-details/Components/PhysiciansComponent/AddPhysicianModal.jsx
@@ -1,0 +1,191 @@
+import PropTypes from 'prop-types';
+
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Button,
+  Checkbox,
+  Group,
+  Modal,
+  Pagination,
+  ScrollArea,
+  Stack,
+  Text,
+  TextInput,
+  Loader,
+  Center,
+  Divider,
+} from '@mantine/core';
+import { useDebouncedValue } from '@mantine/hooks';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { notifications } from '@mantine/notifications';
+
+import LifelineAPI from '#app/LifelineAPI.js';
+
+import { useAvailablePhysicians } from './useAvailablePhysicians.jsx';
+
+const addPhysicianModalProps = {
+  hospitalId: PropTypes.string.isRequired,
+  opened: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  existingPhysicianIds: PropTypes.arrayOf(PropTypes.string).isRequired,
+};
+
+export default function AddPhysicianModal ({
+  hospitalId,
+  opened,
+  onClose,
+  existingPhysicianIds,
+}) {
+  const queryClient = useQueryClient();
+  const [searchValue, setSearchValue] = useState('');
+  const [debouncedSearch] = useDebouncedValue(searchValue, 300);
+  const [page, setPage] = useState(1);
+  const [selected, setSelected] = useState([]);
+
+  const resetState = () => {
+    setSearchValue('');
+    setSelected([]);
+    setPage(1);
+  };
+
+  useEffect(() => {
+    if (!opened) {
+      resetState();
+    }
+  }, [opened]);
+
+  useEffect(() => {
+    setPage(1);
+  }, [debouncedSearch]);
+
+  const { physicians, pages, isFetching, isLoading } = useAvailablePhysicians(
+    debouncedSearch,
+    page,
+    existingPhysicianIds
+  );
+
+  const selectedSet = useMemo(() => new Set(selected), [selected]);
+
+  const toggleSelection = (id) => {
+    setSelected((prev) => {
+      if (prev.includes(id)) {
+        return prev.filter((entry) => entry !== id);
+      }
+
+      return [...prev, id];
+    });
+  };
+
+  const { mutateAsync, isPending } = useMutation({
+    mutationFn: async (physicianIds) => {
+      const response = await LifelineAPI.linkPhysiciansToHospital(
+        hospitalId,
+        physicianIds
+      );
+
+      if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error?.message ?? 'Failed to link physicians.');
+      }
+
+      return response.json();
+    },
+    onSuccess: (result) => {
+      notifications.show({
+        title: 'Physicians linked',
+        message: result?.message ?? 'Physicians linked successfully.',
+        color: 'green',
+      });
+      queryClient.invalidateQueries({ queryKey: ['physicians'], exact: false });
+      queryClient.invalidateQueries({ queryKey: ['availablePhysicians'], exact: false });
+      resetState();
+      onClose();
+    },
+    onError: (error) => {
+      notifications.show({
+        title: 'Unable to link physicians',
+        message: error.message,
+        color: 'red',
+      });
+    },
+  });
+
+  const handleSubmit = async () => {
+    await mutateAsync(selected);
+  };
+
+  const handleCancel = () => {
+    if (isPending) {
+      return;
+    }
+
+    onClose();
+  };
+
+  const renderContent = () => {
+    if ((isLoading || isFetching) && physicians.length === 0) {
+      return (
+        <Center py='lg'>
+          <Loader size='sm' />
+        </Center>
+      );
+    }
+
+    if (physicians.length === 0) {
+      return (
+        <Center py='lg'>
+          <Text c='dimmed'>No physicians available to add.</Text>
+        </Center>
+      );
+    }
+
+    return physicians.map((physician) => (
+      <Checkbox
+        key={physician.id}
+        value={physician.id}
+        checked={selectedSet.has(physician.id)}
+        onChange={() => toggleSelection(physician.id)}
+        label={
+          <Stack gap={2}>
+            <Text fw={600}>{physician.name}</Text>
+            <Text size='sm' c='dimmed'>
+              {physician.email}
+            </Text>
+            <Text size='sm' c='dimmed'>
+              {physician.phone}
+            </Text>
+          </Stack>
+        }
+      />
+    ));
+  };
+
+  return (
+    <Modal opened={opened} onClose={handleCancel} title='Add physicians'>
+      <Stack gap='md'>
+        <TextInput
+          placeholder='Search physicians'
+          value={searchValue}
+          onChange={(event) => setSearchValue(event.currentTarget.value)}
+        />
+        <Divider />
+        <ScrollArea.Autosize mah={280} type='scroll'>
+          <Stack gap='sm'>{renderContent()}</Stack>
+        </ScrollArea.Autosize>
+        {pages > 1 && (
+          <Pagination value={page} onChange={setPage} total={pages} />
+        )}
+        <Group justify='flex-end'>
+          <Button variant='default' onClick={handleCancel} disabled={isPending}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={selected.length === 0} loading={isPending}>
+            Add physicians
+          </Button>
+        </Group>
+      </Stack>
+    </Modal>
+  );
+}
+
+AddPhysicianModal.propTypes = addPhysicianModalProps;

--- a/client/src/pages/hospitals/hospital-details/Components/PhysiciansComponent/Physicians.jsx
+++ b/client/src/pages/hospitals/hospital-details/Components/PhysiciansComponent/Physicians.jsx
@@ -1,27 +1,59 @@
-import {
-  LoadingOverlay,
-} from '@mantine/core';
+import PropTypes from 'prop-types';
+
+import { useMemo } from 'react';
+import { Box, Button, Group, LoadingOverlay, Title } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
 
 import { usePhysicians } from '../../../../physicians/usePhysicians';
 import PhysiciansTable from '../../../../physicians/PhysiciansTable';
+import AddPhysicianModal from './AddPhysicianModal.jsx';
+
+const physiciansProps = {
+  hospitalId: PropTypes.string.isRequired,
+  canEdit: PropTypes.bool,
+};
 
 /**
  *  Physicians page component
  *
  */
-export default function Physicians ({ hospitalId }) {
+export default function Physicians ({ hospitalId, canEdit = false }) {
   const { physicians, headers, isFetching } = usePhysicians(hospitalId);
+  const [modalOpened, { open: openModal, close: closeModal }] = useDisclosure(false);
+
+  const existingPhysicianIds = useMemo(
+    () => (physicians ?? []).map((entry) => entry.id),
+    [physicians]
+  );
 
   return (
     <>
-      <LoadingOverlay
-        visible={isFetching}
-        zIndex={1000}
-        overlayProps={{ radius: 'sm', blur: 2 }}
-      />
-
-      <PhysiciansTable headers={headers} data={physicians} />
-
+      <Group justify='space-between' align='center' mb='sm'>
+        <Title order={2}>Physicians</Title>
+        {canEdit && (
+          <Button onClick={openModal}>
+            Add physician
+          </Button>
+        )}
+      </Group>
+      <Box pos='relative'>
+        <LoadingOverlay
+          visible={isFetching}
+          zIndex={1000}
+          overlayProps={{ radius: 'sm', blur: 2 }}
+        />
+        <PhysiciansTable headers={headers} data={physicians} />
+      </Box>
+      {canEdit && (
+        <AddPhysicianModal
+          hospitalId={hospitalId}
+          opened={modalOpened}
+          onClose={closeModal}
+          existingPhysicianIds={existingPhysicianIds}
+        />
+      )}
     </>
   );
 }
+
+Physicians.propTypes = physiciansProps;

--- a/client/src/pages/hospitals/hospital-details/Components/PhysiciansComponent/useAvailablePhysicians.jsx
+++ b/client/src/pages/hospitals/hospital-details/Components/PhysiciansComponent/useAvailablePhysicians.jsx
@@ -1,0 +1,59 @@
+import { useQuery } from '@tanstack/react-query';
+
+import LifelineAPI from '#app/LifelineAPI.js';
+import { formatPhysicianName } from '../../../../physicians/usePhysicians.jsx';
+
+const formatQueryKey = (excludeIds) => {
+  if (!excludeIds?.length) {
+    return 'none';
+  }
+
+  return [...excludeIds].sort().join(',');
+};
+
+/**
+ * Fetch physicians that can be linked to a hospital.
+ * @param {string} search
+ * @param {number} page
+ * @param {Array<string>} excludeIds
+ * @returns {{ physicians: Array<object>, pages: number, isFetching: boolean, isLoading: boolean }}
+ */
+export function useAvailablePhysicians (search, page, excludeIds) {
+  const { data, isFetching, isLoading } = useQuery({
+    queryKey: ['availablePhysicians', search, page, formatQueryKey(excludeIds)],
+    queryFn: async () => {
+      const response = await LifelineAPI.getPhysicians(search, '', page);
+
+      if (response.status !== 200) {
+        throw new Error('Failed to fetch physicians.');
+      }
+
+      const physicians = await response.json();
+      const pages = +response.headers.get('X-Total-Pages');
+
+      return { physicians, pages };
+    },
+    select: (res) => {
+      const excludeSet = new Set(excludeIds ?? []);
+
+      return {
+        physicians: res.physicians
+          .filter((entry) => !excludeSet.has(entry.id))
+          .map((entry) => ({
+            id: entry.id,
+            name: formatPhysicianName(entry),
+            email: entry.email ?? '-',
+            phone: entry.phone ?? '-',
+          })),
+        pages: res.pages,
+      };
+    },
+  });
+
+  return {
+    physicians: data?.physicians ?? [],
+    pages: data?.pages && data.pages > 0 ? data.pages : 1,
+    isFetching,
+    isLoading,
+  };
+}

--- a/client/src/pages/hospitals/hospital-details/HospitalDetail.jsx
+++ b/client/src/pages/hospitals/hospital-details/HospitalDetail.jsx
@@ -6,7 +6,7 @@ import { Container, Grid, Loader, Text, Title, Group, Button, Paper } from '@man
 
 import { useAuthorization } from '#hooks/useAuthorization.jsx';
 import LifelineAPI from '#app/LifelineAPI.js';
-import PhysiciansTable from './Components/PhysiciansComponent/Physicians.jsx';
+import Physicians from './Components/PhysiciansComponent/Physicians.jsx';
 import Patients from './Components/PatientsComponent/Patients.jsx';
 
 /**
@@ -66,8 +66,7 @@ export default function HospitalDetail () {
           </Paper>
         </Grid.Col>
         <Grid.Col span={{ base: 12, md: 8 }}>
-          <Title order={2} my='sm'> Physicians</Title>
-          <PhysiciansTable hospitalId={hospitalId} />
+          <Physicians hospitalId={hospitalId} canEdit={canEdit} />
         </Grid.Col>
         <Grid.Col span={{ base: 12, md: 8 }}>
           <Title order={2} my='sm'> Patients</Title>

--- a/client/src/pages/physicians/usePhysicians.jsx
+++ b/client/src/pages/physicians/usePhysicians.jsx
@@ -9,7 +9,7 @@ const PHYSICIANS_TABLE_HEADERS = [
   { key: 'more', text: '' },
 ];
 
-const formatName = (entry) => {
+export const formatPhysicianName = (entry) => {
   const formattedName = `${entry.firstName}${entry.middleName ? ` ${entry.middleName}` : ''} ${entry.lastName}`;
   return formattedName.trim() ? formattedName : '-';
 };
@@ -47,7 +47,7 @@ export function usePhysicians (hospitalId) {
   const [search, setSearch] = useState('');
   const [page, setPage] = useState(1);
   const { data, isFetching } = useQuery({
-    queryKey: ['physicians', search, page],
+    queryKey: ['physicians', search, page, hospitalId ?? 'all'],
     queryFn: async () => {
       const res = await LifelineAPI.getPhysicians(search, hospitalId, page);
 
@@ -64,9 +64,9 @@ export function usePhysicians (hospitalId) {
       physicians: res.data.map((physicians) => {
         return {
           id: physicians.id,
-          name: formatName(physicians),
-          email: physicians.email,
-          phone: physicians.phone,
+          name: formatPhysicianName(physicians),
+          email: physicians.email ?? '-',
+          phone: physicians.phone ?? '-',
 
         };
       }),

--- a/server/routes/api/v1/hospitals/physicians.js
+++ b/server/routes/api/v1/hospitals/physicians.js
@@ -1,0 +1,92 @@
+import { StatusCodes } from 'http-status-codes';
+import { z } from 'zod';
+
+import { Role } from '#models/user.js';
+
+export default async function (fastify) {
+  fastify.post(
+    '/:id/physicians',
+    {
+      schema: {
+        params: z.object({
+          id: z.string().uuid('Hospital ID must be a valid UUID'),
+        }),
+        body: z.object({
+          physicianIds: z.array(z.string().uuid()).min(1, 'At least one physician is required'),
+        }),
+        response: {
+          [StatusCodes.OK]: z.object({
+            message: z.string(),
+          }),
+          [StatusCodes.BAD_REQUEST]: z.object({
+            message: z.string(),
+          }),
+          [StatusCodes.NOT_FOUND]: z.object({
+            message: z.string(),
+          }),
+        },
+      },
+      onRequest: fastify.requireUser([Role.ADMIN, Role.STAFF, Role.VOLUNTEER]),
+    },
+    async (request, reply) => {
+      const { id } = request.params;
+      const { physicianIds } = request.body;
+
+      const hospital = await fastify.prisma.hospital.findUnique({
+        where: { id },
+        select: {
+          id: true,
+          physicians: {
+            select: { id: true },
+          },
+        },
+      });
+
+      if (!hospital) {
+        return reply
+          .status(StatusCodes.NOT_FOUND)
+          .send({ message: 'Hospital not found' });
+      }
+
+      const uniqueIds = [...new Set(physicianIds)];
+
+      const physicians = await fastify.prisma.physician.findMany({
+        where: {
+          id: {
+            in: uniqueIds,
+          },
+        },
+        select: { id: true },
+      });
+
+      if (physicians.length !== uniqueIds.length) {
+        return reply.status(StatusCodes.BAD_REQUEST).send({
+          message: 'One or more physicians could not be found.',
+        });
+      }
+
+      const existingIds = new Set(hospital.physicians.map((entry) => entry.id));
+      const toConnect = uniqueIds.filter((physicianId) => !existingIds.has(physicianId));
+
+      if (toConnect.length === 0) {
+        return reply.send({
+          message: 'Selected physicians are already linked to this hospital.',
+        });
+      }
+
+      await fastify.prisma.hospital.update({
+        where: { id },
+        data: {
+          physicians: {
+            connect: toConnect.map((physicianId) => ({ id: physicianId })),
+          },
+          updatedById: request.user.id,
+        },
+      });
+
+      return reply.send({
+        message: 'Physicians linked successfully.',
+      });
+    }
+  );
+}


### PR DESCRIPTION
## Summary
- add an "Add physician" control on the hospital detail page with a modal to pick and link providers
- fetch available physicians while filtering existing associations and reuse shared name formatting helpers
- expose API helpers and a Fastify route so hospitals can connect selected physicians on the backend

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_690401da714c833287da4fccf527cc76